### PR TITLE
Make markup-meta-face legible on a dark background

### DIFF
--- a/markup-faces.el
+++ b/markup-faces.el
@@ -274,9 +274,8 @@ LaTeX: {\\large foo}"
 	       :slant normal
 	       :weight normal
 	       :width normal
-	       :foundry "unknown"))
-    (((background light)) (:foreground "gray65"))
-    (((background dark)) (:foreground "gray30")))
+	       :foundry "unknown"
+	       :foreground "gray65")))
   "Face for general meta characters and base for special meta characters.
 
 The default sets all face properties to a value because then it's


### PR DESCRIPTION
I found that gray30 was impossible to read on a dark background.  For me, gray65 is similarly legible on either a dark or light background, so use that for both.